### PR TITLE
feat : 로그인/로그아웃 메인 화면 틀 잡기 프론트

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,20 +1,18 @@
-import { Link } from "react-router-dom";
-import { getAuthToken, clearAuthToken } from "./api";
+// ===============================
+// 설명: 페이지 쉘(헤더 + 상단 배경 + UploadPage)
+// ===============================
+import React from "react";
+import Header from "./components/Header";
+import UploadPage from "./pages/UploadPage";
 
-export default function App() {
-  const token = getAuthToken();
+export default function App(){
   return (
-    <div style={{padding:24}}>
-      <h1>FastAPI + React Quick Tester</h1>
-      <ul>
-        <li><Link to="/health">/health 확인</Link></li>
-        <li><Link to="/auth">회원가입/로그인/JWT</Link></li>
-        <li><Link to="/summary">AI 요약/QA</Link></li>
-      </ul>
-      <div style={{marginTop:12}}>
-        현재 토큰: {token ? token.slice(0,24) + "..." : "(없음)"}
-        {token && <button style={{marginLeft:8}} onClick={()=>{clearAuthToken(); location.reload()}}>토큰 지우기</button>}
-      </div>
+    <div className="sa-root">
+      <div className="sa-top-bg"/>{/* 상단 라디얼 그라데이션 배경 */}
+      <Header/>
+      <main className="sa-main">
+        <UploadPage/>
+      </main>
     </div>
-  )
+  );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,26 +1,41 @@
+// 토큰 저장/부착 책임 -> 프론트 전역에서 인증 고민 없이
+// Axois 인스턴스 + JWT 저장/첨부 공통 헬퍼
+
 import axios from "axios";
 
-const api = axios.create({ baseURL: "/api" });
 
-// --- 토큰 저장/적용 유틸 ---
-const TOKEN_KEY = "demo_token";
+// 로컬스토리지에 JWT를 저장할 때 사용할 key 이름(임의 문자열)
+export const TOKEN_KEY = "auth_token";
 
-export function setAuthToken(token: string) {
-  localStorage.setItem(TOKEN_KEY, token);
-}
 
-export function getAuthToken(): string | null {
-  return localStorage.getItem(TOKEN_KEY);
-}
+// 현재 저장된 토큰 조회
+export const getAuthToken = () => localStorage.getItem(TOKEN_KEY);
 
-export function clearAuthToken() {
-  localStorage.removeItem(TOKEN_KEY);
-}
 
+// 토큰 저장/삭제 (undefined 전달 시 삭제)
+export const setAuthToken = (t?: string) => {
+if (t) localStorage.setItem(TOKEN_KEY, t);
+else localStorage.removeItem(TOKEN_KEY);
+};
+
+
+// 모든 API 호출은 이 인스턴스를 사용
+const api = axios.create({ baseURL: "/api", withCredentials: true });
+
+
+// 요청 직전에 Authorization 헤더에 Bearer 토큰 자동 첨부
 api.interceptors.request.use((config) => {
-  const token = getAuthToken();
-  if (token) config.headers.Authorization = `Bearer ${token}`;
-  return config;
+const token = getAuthToken();
+if (token) config.headers.Authorization = `Bearer ${token}`;
+return config;
 });
+
+
+// 응답이 401(만료/무효)면 토큰 제거 → 사실상의 로그아웃 상태로 전환
+api.interceptors.response.use(undefined, (err) => {
+if (err?.response?.status === 401) setAuthToken(undefined);
+return Promise.reject(err);
+});
+
 
 export default api;

--- a/frontend/src/auth.tsx
+++ b/frontend/src/auth.tsx
@@ -1,0 +1,58 @@
+// 인증 컨텍스트 (로그인/로그아웃/내 정보 조회)
+
+import React, { createContext, useContext, useEffect, useState } from "react";
+import api, { getAuthToken, setAuthToken } from "./api";
+
+export type User = { id: string; email: string } | null;
+
+type AuthCtx = {
+  user: User;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => void;
+  refresh: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthCtx>({
+  user: null,
+  login: async () => {},
+  logout: () => {},
+  refresh: async () => {},
+});
+
+export const useAuth = () => useContext(AuthContext);
+
+export function AuthProvider({ children }: { children: React.ReactNode }) {
+  const [user, setUser] = useState<User>(null);
+
+  // /users/me 로 현재 사용자 조회 → 상단 이메일/버튼 표시용
+  async function refresh() {
+    if (!getAuthToken()) { setUser(null); return; }
+    try {
+      const { data } = await api.get("/users/me");
+      setUser(data);
+    } catch {
+      setUser(null);
+    }
+  }
+  useEffect(() => { refresh(); }, []);
+
+  // fastapi-users 로그인: x-www-form-urlencoded 필요
+  async function login(email: string, password: string) {
+    const form = new URLSearchParams();
+    form.append("username", email);
+    form.append("password", password);
+    const { data } = await api.post("/auth/jwt/login", form, {
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+    });
+    setAuthToken(data.access_token); // 로컬스토리지에 토큰 저장
+    await refresh();                 // /users/me 재호출하여 user 상태 갱신
+  }
+  function logout(){ setAuthToken(undefined); setUser(null); }
+
+  return (
+    <AuthContext.Provider value={{ user, login, logout, refresh }}>
+      {children}
+    </AuthContext.Provider>
+  );
+}
+

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,41 @@
+// ===============================
+// 설명: 헤더(로고/부제목, Beta, 로그인/로그아웃)
+// ===============================
+import React, { useState } from "react";
+import { useAuth } from "../auth";
+import LoginModal from "./LoginModal";
+
+
+export default function Header(){
+  const { user, logout } = useAuth();
+  const [openLogin, setOpenLogin] = useState(false);
+  return (
+    <header className="sa-header">
+      <div className="sa-header__left">
+        {/* 로고(아이콘 + 텍스트) */}
+        <div className="sa-logo">
+          <div className="sa-logo__icon">
+            <svg viewBox="0 0 24 24" width="22" height="22" fill="none"><circle cx="12" cy="12" r="10" fill="#6f5bff"/><path d="M8 12l2.2 2.2L16 8.5" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>
+          </div>
+          <div className="sa-logo__text">
+            <div className="sa-logo__title">StudyAI</div>
+            <div className="sa-logo__subtitle">AI 기반 스마트 학습 플랫폼</div>
+          </div>
+        </div>
+      </div>
+      <div className="sa-header__right">
+        <span className="sa-badge">Beta</span>
+        {user ? (
+          <div className="sa-user">
+            <span className="sa-user__email">{user.email}</span>
+            <button className="sa-btn ghost" onClick={logout}>로그아웃</button>
+          </div>
+        ) : (
+          <button className="sa-btn" onClick={()=>setOpenLogin(true)}>로그인</button>
+        )}
+      </div>
+      {/* 로그인 모달 */}
+      <LoginModal open={openLogin} onClose={()=>setOpenLogin(false)} />
+    </header>
+  );
+}

--- a/frontend/src/components/LoginModal.tsx
+++ b/frontend/src/components/LoginModal.tsx
@@ -1,0 +1,39 @@
+// ===============================
+// 설명: 로그인 모달 → /api/auth/jwt/login 호출 후 토큰 저장
+// ===============================
+import React, { useState } from "react";
+import { useAuth } from "../auth";
+import Modal from "./Modal";
+
+export default function LoginModal({ open, onClose }:{ open: boolean; onClose: () => void }){
+  const { login } = useAuth();
+  const [email, setEmail] = useState("");
+  const [pw, setPw] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string|undefined>();
+
+  async function onSubmit(){
+    setLoading(true); setError(undefined);
+    try { await login(email, pw); onClose(); }
+    catch(e:any){ setError(e?.response?.data?.detail || "로그인 실패"); }
+    finally { setLoading(false); }
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="로그인">
+      <div className="sa-field">
+        <label>이메일</label>
+        <input value={email} onChange={(e)=>setEmail(e.target.value)} placeholder="you@example.com" />
+      </div>
+      <div className="sa-field">
+        <label>비밀번호</label>
+        <input type="password" value={pw} onChange={(e)=>setPw(e.target.value)} placeholder="••••••••" />
+      </div>
+      {error && <div className="sa-error">{error}</div>}
+      <div className="sa-actions">
+        <button className="sa-btn ghost" onClick={onClose}>취소</button>
+        <button className="sa-btn primary" onClick={onSubmit} disabled={loading}>{loading?"로그인 중…":"로그인"}</button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/Modal.tsx
+++ b/frontend/src/components/Modal.tsx
@@ -1,0 +1,19 @@
+// ===============================
+// 설명: 화면 공통 모달(뒷배경 + 카드)
+// ===============================
+import React from "react";
+
+export default function Modal({ open, onClose, width = 520, title, children, footer }:{
+  open: boolean; onClose: () => void; width?: number; title?: string; children?: React.ReactNode; footer?: React.ReactNode;
+}){
+  if (!open) return null;
+  return (
+    <div className="sa-modal__backdrop" onClick={onClose}>
+      <div className="sa-modal" style={{ width }} onClick={(e)=>e.stopPropagation()}>
+        {title && <div className="sa-modal__title">{title}</div>}
+        <div className="sa-modal__body">{children}</div>
+        {footer && <div className="sa-modal__footer">{footer}</div>}
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/SubjectModal.tsx
+++ b/frontend/src/components/SubjectModal.tsx
@@ -1,0 +1,66 @@
+
+
+// ===============================
+// 설명: 과목 검색/선택/즉시 생성 모달 (/subjects)
+// ===============================
+import React, { useEffect, useMemo, useState } from "react";
+import api from "../api";
+import Modal from "./Modal";
+
+type Subject = { subject_id: number; name: string };
+
+function useDebounce<T>(v: T, ms=300){
+  const [d,setD]=useState(v);
+  useEffect(()=>{ const t=setTimeout(()=>setD(v),ms); return ()=>clearTimeout(t); },[v,ms]);
+  return d;
+}
+
+export default function SubjectModal({ open, onClose, onPick }:{ open: boolean; onClose: () => void; onPick: (s:Subject)=>void; }){
+  const [q, setQ] = useState("");
+  const dq = useDebounce(q);
+  const [items, setItems] = useState<Subject[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  // 목록 로드/검색
+  async function load(query?: string){
+    setLoading(true);
+    const { data } = await api.get<Subject[]>("/subjects", { params: query?{ q: query }:{} });
+    setItems(data); setLoading(false);
+  }
+  useEffect(()=>{ if(open){ load(); setQ(""); } }, [open]);
+  useEffect(()=>{ if(open && dq) load(dq); }, [open, dq]);
+
+  // 검색어가 목록에 없으면 "+ 새 과목 생성" 노출
+  const showCreate = useMemo(()=>{
+    const t=q.trim(); if(!t) return false; return !items.some(i=>i.name===t);
+  },[q,items]);
+
+  async function createNew(){
+    const name=q.trim(); if(!name) return;
+    const { data } = await api.post<Subject>("/subjects", { name });
+    onPick(data); onClose();
+  }
+
+  return (
+    <Modal open={open} onClose={onClose} title="과목 선택" width={560}>
+      <div className="sa-field">
+        <input autoFocus placeholder="과목명 검색 (예: 정처기)" value={q} onChange={(e)=>setQ(e.target.value)} />
+      </div>
+      <div className="sa-list">
+        {loading && <div className="sa-list__item">불러오는 중…</div>}
+        {!loading && items.map(s=> (
+          <div key={s.subject_id} className="sa-list__item selectable" onClick={()=>{ onPick(s); onClose(); }}>{s.name}</div>
+        ))}
+        {!loading && showCreate && (
+          <div className="sa-list__item create" onClick={createNew}>+ "{q.trim()}" 새 과목 생성</div>
+        )}
+        {!loading && items.length===0 && !showCreate && (
+          <div className="sa-list__item">검색 결과 없음</div>
+        )}
+      </div>
+      <div className="sa-actions">
+        <button className="sa-btn ghost" onClick={onClose}>닫기</button>
+      </div>
+    </Modal>
+  );
+}

--- a/frontend/src/components/Tabs.tsx
+++ b/frontend/src/components/Tabs.tsx
@@ -1,0 +1,16 @@
+// 탭 네비게이션
+// 설명: 상단 라운드 탭바(자료 업로드 활성)
+// ===============================
+import React from "react";
+
+export default function Tabs(){
+  return (
+    <nav className="sa-tabs">
+      <a className="sa-tab active">📤 자료 업로드</a>
+      <a className="sa-tab">🧠 요약 & Q&A</a>
+      <a className="sa-tab">❓ 문제 생성</a>
+      <a className="sa-tab">📘 문제 풀이</a>
+      <a className="sa-tab">📊 학습 분석</a>
+    </nav>
+  );
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,21 +1,16 @@
-import React from 'react'
-import ReactDOM from 'react-dom/client'
-import { createBrowserRouter, RouterProvider } from 'react-router-dom'
-import App from './App'
-import Health from './pages/Health'
-import AuthPage from './pages/AuthPage'
-import SummaryPage from './pages/SummaryPage'
-import './index.css'
+// ===============================
+// 설명: 엔트리 — AuthProvider로 감싸고 전역 CSS 로드
+// ===============================
+import React from "react";
+import ReactDOM from "react-dom/client";
+import App from "./App";
+import { AuthProvider } from "./auth";
+import "./styles.css"; // 레퍼런스 룩앤필 CSS
 
-const router = createBrowserRouter([
-  { path: '/', element: <App/> },
-  { path: '/health', element: <Health/> },
-  { path: '/auth', element: <AuthPage/> },
-  { path: '/summary', element: <SummaryPage/> },
-])
-
-ReactDOM.createRoot(document.getElementById('root')!).render(
+ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <RouterProvider router={router}/>
+    <AuthProvider>
+      <App/>
+    </AuthProvider>
   </React.StrictMode>
-)
+);

--- a/frontend/src/pages/UploadPage.tsx
+++ b/frontend/src/pages/UploadPage.tsx
@@ -1,0 +1,95 @@
+// "자료 업로드" 탭 페이지
+
+// ===============================
+// 설명: 본 화면(히어로 + 탭 + 업로드 카드)
+// ===============================
+import React, { useRef, useState } from "react";
+import { useAuth } from "../auth";
+import api from "../api";
+import SubjectModal from "../components/SubjectModal";
+import Tabs from "../components/Tabs";
+
+type Subject = { subject_id: number; name: string };
+
+export default function UploadPage(){
+  const { user } = useAuth();
+  const [subject, setSubject] = useState<Subject|null>(null);
+  const [openSubject, setOpenSubject] = useState(false);
+  const [file, setFile] = useState<File|undefined>();
+  const [text, setText] = useState("");
+  const [out, setOut] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const dropRef = useRef<HTMLDivElement>(null);
+
+  function requireLogin(action: ()=>void){ if(!user){ alert("먼저 로그인해주세요."); return; } action(); }
+
+  // 드래그앤드롭 비주얼 상태
+  function onDrop(e: React.DragEvent){ e.preventDefault(); const f=e.dataTransfer.files?.[0]; if(f) setFile(f); dropRef.current?.classList.remove("dragover"); }
+  function onDragOver(e: React.DragEvent){ e.preventDefault(); dropRef.current?.classList.add("dragover"); }
+  function onDragLeave(){ dropRef.current?.classList.remove("dragover"); }
+
+  async function submit(){
+    if(!user){ alert("로그인이 필요합니다."); return; }
+    if(!subject){ alert("과목을 선택/생성하세요."); return; }
+    if(!file && !text.trim()){ alert("파일 또는 텍스트 중 하나를 입력하세요."); return; }
+
+    const form = new FormData();
+    form.append("subject_id", String(subject.subject_id));
+    if(file) form.append("file", file);
+    if(text.trim()) form.append("text", text.trim());
+
+    const { data } = await api.post("/documents/upload", form, { headers: { "Content-Type":"multipart/form-data" } });
+    setOut(JSON.stringify(data, null, 2));
+  }
+
+  return (
+    <div className="sa-container">
+      {/* 히어로 영역 (타이틀/서브카피) */}
+      <section className="sa-hero">
+        <h1 className="sa-hero__title">AI로 더 효율적인 학습을 시작하세요</h1>
+        <p className="sa-hero__subtitle">자료 업로드부터 문제 풀이까지, 모든 학습 과정을 AI가 도와드립니다.</p>
+      </section>
+
+      {/* 탭바 */}
+      <Tabs/>
+
+      {/* 업로드 카드 */}
+      <section className="sa-card">
+        <div className="sa-card__header">
+          <div className="sa-card__title"><span className="sa-title-icon"/>학습 자료 업로드</div>
+          <div className="sa-card__actions">
+            <button className="sa-btn ghost" onClick={()=>requireLogin(()=>setOpenSubject(true))}>
+              {subject?`선택된 과목: ${subject.name}`:"과목 선택"}
+            </button>
+          </div>
+        </div>
+        <p className="sa-card__desc">PDF, 이미지, 문서 파일을 업로드하여 AI가 자동으로 분석합니다</p>
+
+        <div ref={dropRef} className="sa-dropzone" onDrop={onDrop} onDragOver={onDragOver} onDragLeave={onDragLeave}>
+          <input ref={inputRef} type="file" accept=".pdf,.doc,.docx,.txt,.jpg,.jpeg,.png" onChange={(e)=>setFile(e.target.files?.[0]||undefined)} style={{display:"none"}}/>
+          <div className="sa-dropzone__inner">
+            <div className="sa-upload-badge">
+              <svg width="28" height="28" viewBox="0 0 24 24" fill="none"><path d="M12 16V8" stroke="#fff" strokeWidth="2" strokeLinecap="round"/><path d="M8.5 11.5L12 8l3.5 3.5" stroke="#fff" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"/></svg>
+            </div>
+            <div className="sa-dropzone__title">파일을 여기엔 드래그하거나</div>
+            <div className="sa-dropzone__subtitle">아래 버튼을 클릭하여 파일을 선택하세요</div>
+            <button className="sa-btn primary" onClick={()=>inputRef.current?.click()}>파일 선택하기</button>
+            <div className="sa-dropzone__meta"><span>• PDF, DOC, TXT</span><span>• JPG, PNG</span><span>• 최대 10MB</span></div>
+          </div>
+        </div>
+
+        <div className="sa-or">또는 텍스트 붙여넣기</div>
+        <textarea className="sa-textarea" rows={6} placeholder="긴 텍스트를 붙여넣을 수 있어요." value={text} onChange={(e)=>setText(e.target.value)} />
+
+        <div className="sa-card__footer">
+          <button className="sa-btn primary" onClick={submit}>업로드</button>
+        </div>
+
+        {out && <pre className="sa-result">{out}</pre>}
+      </section>
+
+      {/* 과목 선택/생성 모달 */}
+      <SubjectModal open={openSubject} onClose={()=>setOpenSubject(false)} onPick={setSubject} />
+    </div>
+  );
+}

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,78 @@
+
+/*
+설명: 레퍼런스 스크린 룩앤드필(그라데이션/카드/점선/버튼 등)
+*/
+:root{ --ink:#0f172a; --sub:#6b7280; --ring:#e2e8f0; --card:#fff; --indigo:#6f5bff; --shadow: 0 10px 30px rgba(17,24,39,.08); }
+*{box-sizing:border-box}
+html,body,#root{height:100%}
+body{margin:0; font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Noto Sans KR, Helvetica, Arial; color:var(--ink); background:#fff}
+
+/* 레이아웃 */
+.sa-root{position:relative; min-height:100vh}
+.sa-top-bg{position:absolute; inset:0 0 auto 0; height:220px; background:radial-gradient(1200px 220px at 50% -40px, #efeaff 0%, #ffffff 60%); z-index:0}
+.sa-main{position:relative; z-index:1; max-width:1160px; margin:0 auto; padding:32px 24px 80px}
+
+/* 헤더 */
+.sa-header{position:relative; z-index:2; max-width:1160px; margin:0 auto; padding:16px 24px; display:flex; align-items:center; justify-content:space-between}
+.sa-logo{display:flex; align-items:center; gap:12px}
+.sa-logo__icon{display:grid; place-items:center; width:40px; height:40px; border-radius:12px; background:linear-gradient(180deg, #8a7bff, #6f5bff); box-shadow:0 6px 18px rgba(111,91,255,.35)}
+.sa-logo__text{display:flex; flex-direction:column}
+.sa-logo__title{font-weight:800; font-size:20px}
+.sa-logo__subtitle{font-size:12px; color:var(--sub)}
+.sa-header__right{display:flex; align-items:center; gap:12px}
+.sa-badge{padding:6px 10px; font-size:12px; border-radius:999px; background:#eef2ff; color:#4f46e5}
+.sa-user{display:flex; align-items:center; gap:8px}
+.sa-user__email{font-size:14px; color:#475569}
+
+/* 버튼 */
+.sa-btn{appearance:none; border:0; background:#111827; color:#fff; padding:10px 14px; border-radius:10px; font-weight:600; cursor:pointer}
+.sa-btn.primary{background:linear-gradient(180deg,#7c6cff,#5f49ff); box-shadow:0 10px 24px rgba(95,73,255,.35)}
+.sa-btn.ghost{background:transparent; color:#374151; border:1px solid var(--ring)}
+.sa-btn:disabled{opacity:.6; cursor:not-allowed}
+
+/* 히어로 & 탭 */
+.sa-hero__title{font-size:40px; font-weight:800; letter-spacing:-.5px; margin:24px 0 8px}
+.sa-hero__subtitle{color:var(--sub); margin:0 0 20px}
+.sa-tabs{display:flex; gap:12px; background:#fff; padding:6px; border-radius:999px; box-shadow:var(--shadow); width:max-content}
+.sa-tab{padding:10px 18px; border-radius:999px; color:#374151; text-decoration:none; font-weight:600}
+.sa-tab.active{background:#111827; color:#fff}
+
+/* 카드 */
+.sa-card{background:var(--card); border-radius:16px; box-shadow:var(--shadow); border:1px solid #eef2ff; padding:24px; margin-top:24px}
+.sa-card__header{display:flex; align-items:center; justify-content:space-between; gap:12px}
+.sa-card__title{display:flex; align-items:center; gap:10px; font-weight:800; font-size:18px}
+.sa-title-icon{width:28px; height:28px; border-radius:999px; background:linear-gradient(180deg,#8a7bff,#6f5bff); display:inline-block}
+.sa-card__actions{display:flex; gap:8px}
+.sa-card__desc{color:var(--sub); margin:6px 0 14px}
+
+/* 드롭존 */
+.sa-dropzone{border:2px dashed #d9ddec; border-radius:16px; min-height:280px; display:flex; align-items:center; justify-content:center; background:linear-gradient(180deg,#fbfbff,#ffffff)}
+.sa-dropzone.dragover{background:#f7f8ff; border-color:#c4c8f5}
+.sa-dropzone__inner{display:grid; justify-items:center; gap:10px; padding:36px}
+.sa-upload-badge{width:64px; height:64px; border-radius:999px; display:grid; place-items:center; background:radial-gradient(60px 60px at 50% 35%, #9a8cff 0%, #6f5bff 70%); color:#fff; box-shadow:0 12px 28px rgba(111,91,255,.35)}
+.sa-dropzone__title{font-weight:800; font-size:18px}
+.sa-dropzone__subtitle{color:var(--sub); font-size:14px}
+.sa-dropzone__meta{display:flex; gap:18px; color:var(--sub); font-size:13px; margin-top:6px}
+
+/* 보조 입력/풋터 */
+.sa-or{margin:18px 0 8px; color:var(--sub)}
+.sa-textarea{width:100%; border:1px solid var(--ring); border-radius:12px; padding:12px; resize:vertical; min-height:120px}
+.sa-card__footer{margin-top:14px; display:flex; justify-content:flex-end}
+.sa-result{white-space:pre-wrap; background:#0b1020; color:#e5e7eb; padding:16px; border-radius:12px; margin-top:14px}
+
+/* 모달 */
+.sa-modal__backdrop{position:fixed; inset:0; background:rgba(0,0,0,.35); display:grid; place-items:center; z-index:50}
+.sa-modal{background:#fff; border-radius:16px; padding:18px 18px 16px; box-shadow:0 20px 60px rgba(0,0,0,.25); border:1px solid #eef2ff}
+.sa-modal__title{font-weight:800; font-size:18px; margin-bottom:10px}
+.sa-modal__body{display:grid; gap:10px}
+.sa-modal__footer, .sa-actions{display:flex; justify-content:flex-end; gap:8px; margin-top:10px}
+.sa-field{display:grid; gap:6px}
+.sa-field > label{font-size:13px; color:var(--sub)}
+.sa-field > input{border:1px solid var(--ring); padding:10px 12px; border-radius:10px}
+.sa-error{color:#ef4444; font-size:13px}
+.sa-list{border:1px solid var(--ring); border-radius:12px; max-height:260px; overflow:auto}
+.sa-list__item{padding:10px 12px; border-bottom:1px solid #eef2ff}
+.sa-list__item:last-child{border-bottom:none}
+.sa-list__item.selectable{cursor:pointer}
+.sa-list__item.selectable:hover{background:#f7f7ff}
+.sa-list__item.create{color:#5f49ff; font-weight:700; cursor:pointer}


### PR DESCRIPTION
### 수정한 코드 부분 캡쳐본입니다.
<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/455aae99-3d15-4969-9c0f-181f8f0ed645" />

<br>

### 수정한 부분 파일의 역할은 아래와 같습니다.
- src/api.ts — Axios 인스턴스/토큰 저장·자동첨부
- src/auth.tsx — 인증 컨텍스트(로그인/로그아웃/내정보)
- src/components/Modal.tsx — 공통 모달
- src/components/Header.tsx — 헤더 + 로그인 버튼/모달 연동
- src/components/LoginModal.tsx — 로그인 폼(/auth/jwt/login)
- src/components/SubjectModal.tsx — 과목 검색/선택/즉시 생성(/subjects)
- src/components/Tabs.tsx — 상단 라운드 탭(“자료 업로드” 활성)
- src/pages/UploadPage.tsx — 히어로/탭/업로드 카드/드롭존/텍스트/업로드
- src/App.tsx — 상단 라디얼 배경 + 헤더 + 본문
- src/main.tsx — 엔트리(AuthProvider로 감싸고 CSS 로드)
- src/styles.css — 레퍼런스 룩앤필 CSS(그라데이션/카드/점선/버튼 등)